### PR TITLE
Add mosh to installed packages

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,3 +7,4 @@
     - iperf
     - git
     - htop
+    - mosh


### PR DESCRIPTION
Remote terminal application that allows roaming, supports intermittent connectivity, and provides intelligent local echo and line editing of user keystrokes.

Mosh is a replacement for SSH. It's more robust and responsive, especially over Wi-Fi, cellular, and long-distance links.

Major benefits:

* Stay connected when roaming
    * wired in then going wireless
    * resuming from sleep
* No echo lag - never be stuck again not knowing what you typed
* ^C always works - control commands go to the front of the send buffer
* Uses SSH to start the connection then switches to its own encrypted UDP protocol

My presentation on it: https://github.com/colindean/talks/blob/master/lightning/mosh/mosh.md